### PR TITLE
Initialize average charge variable

### DIFF
--- a/main.c
+++ b/main.c
@@ -265,7 +265,7 @@ int main() {
   preparationCommandes(); // Initialisation des commandes
 
   agv1_arrivee_prod(); // Initialisation du premier evenement
-  double chargeMoyenneAVG;
+  double chargeMoyenneAVG = 0.0;
 
   while (t < H) {
     if (event_count >= MAX_EVENTS) {


### PR DESCRIPTION
## Summary
- initialize `chargeMoyenneAVG` to avoid undefined value

## Testing
- `gcc -o main main.c -lm`
- `./main > out_after.txt`

------
https://chatgpt.com/codex/tasks/task_e_684c382e5f6c832787f21ecc5ad1bf99